### PR TITLE
Update installation.md for nutpie instructions

### DIFF
--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -32,3 +32,14 @@ conda install blackjax
 ```
 
 Note that JAX is not directly supported on Windows systems at the moment.
+
+## Nutpie sampling
+
+You can also enable sampling with [nutpie](https://github.com/pymc-devs/nutpie). 
+Nutpie uses numba as the compiler and a sampler written in Rust for faster performance.
+
+```console
+conda install -c conda-forge nutpie
+```
+
+Unlike JAX, nutpie is directly supported on Windows.


### PR DESCRIPTION
https://github.com/pymc-devs/pymc/issues/6851

I verified that the conda + conda-forge instructions work after getting a fresh install of pymc. I suspect this will be the simplest install instructions that work for most users. If they want further ideas, they can follow the link to the nutpie page for mamba, source or pip install commands. Mostly I think this change serves as a good advertisement for nutpie and will encourage more folks to try it out.

<!-- readthedocs-preview pymc start -->
----
:books: Documentation preview :books:: https://pymc--2.org.readthedocs.build/en/2/

<!-- readthedocs-preview pymc end -->